### PR TITLE
Fixes #2

### DIFF
--- a/PictureBitmapDrawable.cs
+++ b/PictureBitmapDrawable.cs
@@ -13,6 +13,9 @@ namespace XamSvg
 	public class PictureBitmapDrawable : Drawable
 	{
 		Bitmap currentBitmap;
+		
+		public PictureBitmapDrawable(IntPtr handle, JniHandleOwnership transfer) 
+            		: base(handle, transfer) { }
 
 		public PictureBitmapDrawable (Picture pic)
 		{
@@ -26,7 +29,8 @@ namespace XamSvg
 
 		public override void Draw (Canvas canvas)
 		{
-			canvas.DrawBitmap (currentBitmap, 0, 0, null);
+			if (currentBitmap != null)
+				canvas.DrawBitmap (currentBitmap, 0, 0, null);
 		}
 
 		public override int Opacity {
@@ -39,8 +43,11 @@ namespace XamSvg
 		{
 			var width = bounds.Width ();
 			var height = bounds.Height ();
-			if (currentBitmap == null || currentBitmap.Height != height || currentBitmap.Width != width)
-				currentBitmap = SvgFactory.MakeBitmapFromPicture (Picture, width, height);
+			if (width <= 0 || height <= 0)
+                		return;
+
+            		if (Picture != null && (currentBitmap == null || currentBitmap.Height != height || currentBitmap.Width != width))
+                		currentBitmap = SvgFactory.MakeBitmapFromPicture(Picture, width, height);
 		}
 
 		public override int IntrinsicWidth {


### PR DESCRIPTION
As mentioned in #2, a ctor was missing for the `PictureBitmapDrawable`, I think this was added with 4.8 if I recall correctly, where derivatives of Java types need to have this ctor.

I also added some guards as sometimes the `Rect` passed into `OnBoundsChange` have their width and height set to 0, which crashes the app. This happens when using the `Drawable` in a `Fragment` and the `ImageView` hasn't been measured or drawn yet.
